### PR TITLE
Fix warning pkg source not found

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -8,7 +8,7 @@ cask "inspec" do
   name "InSpec by Chef"
   homepage "https://www.inspec.io/"
 
-  pkg "inspec-#{version}.pkg"
+  pkg "inspec-#{version}-1.pkg"
 
   # As suggested in https://docs.chef.io/install_dk.html#mac-os-x
   uninstall_postflight do


### PR DESCRIPTION
Error: pkg source file not found: 'inspec-2.2.55.pkg'

I'm not sure if this is how you want it to be fixed, but it removes the error.