### PR TITLE
Bumped InSpec to 3.0.12 and removed hardcoded MacOS variable.

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -1,9 +1,9 @@
 cask "inspec" do
-  version "3.0.9"
-  sha256 "4d7a1ab6040b402b7cc7353fb9c69df67ac749f998f119f52d5c80906dfd5987"
+  version "3.0.12"
+  sha256 "5512d246162946730d055eb5cb1196e795585a67bd311836a58650a456415059"
 
   # packages.chef.io was verified as official when first introduced to the cask
-  url "https://packages.chef.io/files/stable/inspec/#{version}/mac_os_x/10.13/inspec-#{version}-1.dmg"
+  url "https://packages.chef.io/files/stable/inspec/#{version}/mac_os_x/#{MacOS.version}/inspec-#{version}-1.dmg"
   appcast "https://github.com/chef/inspec/releases.atom"
   name "InSpec by Chef"
   homepage "https://www.inspec.io/"


### PR DESCRIPTION
Signed-off-by: Karl Fischer <kmf@kmf.co>