### PR TITLE
Adding debug information for when update_version.sh fails

### DIFF
--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -3,13 +3,13 @@
 # This bumps the version in the ENV var 'VERSION' on the project specified
 # It fetches the sha256 via omnitruck api
 
-set -e
+set -ex
 
 # make sure the API is ready to return a new product
 sleep 240
 
 URL="https://omnitruck.chef.io/stable/$PRODUCT_KEY/metadata?p=mac_os_x&pv=10.13&m=x86_64&v=$VERSION"
-SHA="$(curl -Ss $URL | sed -n 's/sha256\s*\(\S*\)/\1/p')"
+SHA="$(curl -Ssv $URL | sed -n 's/sha256\s*\(\S*\)/\1/p')"
 
 # make sure we got back a sha256 value
 if [ -z "$SHA" ]; then

--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,6 +1,6 @@
 cask 'chef-workstation' do
-  version '0.2.29'
-  sha256 '19c1624a7d0fbf02cd84f08219acce7a1463c16f528cad681231ca6142b259d0'
+  version "0.2.29"
+  sha256 "19c1624a7d0fbf02cd84f08219acce7a1463c16f528cad681231ca6142b259d0"
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.13/chef-workstation-#{version}-1.dmg"
   name 'Chef Workstation'


### PR DESCRIPTION
Signed-off-by: tyler-ball <tball@chef.io>

@tas50 There was also a bug where it would not have updated the Workstation version even if it did get past the curl/sed step.