### PR TITLE
Bump Chef Infra to 15.2.20 and update the expeditor config

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -3,7 +3,10 @@
 
 # Slack channel in Chef Software slack to send notifications about build failures, etc
 slack:
-  notify_channel: chef-found-notify
+  notify_channel:
+    - chef-ws-notify
+    - chef-infra-notify
+    - inspec-notify
 
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch

--- a/.expeditor/update_version.sh
+++ b/.expeditor/update_version.sh
@@ -15,8 +15,8 @@ function get_sha() {
   curl -Ssv $URL | sed -n 's/sha256\s*\(\S*\)/\1/p'
 }
 
-echo "Sleeping for 10 minutes to let omnitruck catch up"
-sleep 600
+echo "Sleeping for 15 minutes to let omnitruck catch up"
+sleep 900
 
 tries=12
 for (( i=1; i<=$tries; i+=1 )); do

--- a/Casks/chef-infra-client.rb
+++ b/Casks/chef-infra-client.rb
@@ -1,6 +1,6 @@
 cask "chef-infra-client" do
-  version "15.1.36"
-  sha256 "757d04d45433450cbe4e240117f38a318a89db325f22fc40338cbb6eb51671e8"
+  version "15.2.20"
+  sha256 "88a35411f5068d93fec00762ad96579d70a40347aea3067a79050a15503ab298"
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/chef/#{version}/mac_os_x/#{MacOS.version}/chef-#{version}-1.dmg"


### PR DESCRIPTION
Notify all our channels
Wait 15 minutes since 10 isn't enough for omnitruck with chef/chef

Signed-off-by: Tim Smith <tsmith@chef.io>