### PR TITLE
Resolve failures installing on macOS 11.x

### DIFF
--- a/Casks/chef-infra-client.rb
+++ b/Casks/chef-infra-client.rb
@@ -5,7 +5,7 @@ cask "chef-infra-client" do
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/chef/#{version}/mac_os_x/10.14/chef-#{version}-1.dmg"
   name "Chef Infra Client"
-  homepage "https://www.chef.io/"
+  homepage "https://community.chef.io/tools/chef-infra/"
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/chef-infra-client.rb
+++ b/Casks/chef-infra-client.rb
@@ -3,7 +3,7 @@ cask "chef-infra-client" do
   sha256 "3cb8d84a715c7f63b249b2f69e042889515eba9a6e82d41b7630861bce4728fa"
 
   # packages.chef.io was verified as official when first introduced to the cask
-  url "https://packages.chef.io/files/stable/chef/#{version}/mac_os_x/#{MacOS.version}/chef-#{version}-1.dmg"
+  url "https://packages.chef.io/files/stable/chef/#{version}/mac_os_x/10.14/chef-#{version}-1.dmg"
   name "Chef Infra Client"
   homepage "https://www.chef.io/"
 

--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -4,7 +4,7 @@ cask "chef-workstation" do
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.14/chef-workstation-#{version}-1.dmg"
   name "Chef Workstation"
-  homepage "https://www.chef.sh/"
+  homepage "https://community.chef.io/tools/chef-workstation/"
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -2,7 +2,7 @@ cask "chef-workstation" do
   version "21.1.222"
   sha256 "c1a3ee7290b25366b3c6b002948d13c880fe627e2e7026825dde46baf45b3b96"
 
-  url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.13/chef-workstation-#{version}-1.dmg"
+  url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.14/chef-workstation-#{version}-1.dmg"
   name "Chef Workstation"
   homepage "https://www.chef.sh/"
 

--- a/Casks/chefdk.rb
+++ b/Casks/chefdk.rb
@@ -2,7 +2,7 @@ cask "chefdk" do
   version "4.13.3"
   sha256 "a38e995e6a83856df64875dcc2424fe961b7dee9fca90a1290ddd1f01399ebf8"
 
-  url "https://packages.chef.io/files/stable/chefdk/#{version}/mac_os_x/#{MacOS.version}/chefdk-#{version}-1.dmg"
+  url "https://packages.chef.io/files/stable/chefdk/#{version}/mac_os_x/10.14/chefdk-#{version}-1.dmg"
   appcast "https://www.chef.io/chef/metadata-chefdk?p=mac_os_x&pv=#{MacOS.version}&m=x86_64&v=latest&prerelease=false"
   name "Chef Development Kit"
   name "ChefDK"

--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -6,7 +6,7 @@ cask "inspec" do
   url "https://packages.chef.io/files/stable/inspec/#{version}/mac_os_x/10.14/inspec-#{version}-1.dmg"
   appcast "https://github.com/chef/inspec/releases.atom"
   name "InSpec by Chef"
-  homepage "https://www.inspec.io/"
+  homepage "https://community.chef.io/tools/chef-inspec/"
 
   depends_on macos: ">= :high_sierra"
 

--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -3,7 +3,7 @@ cask "inspec" do
   sha256 "d7023785512eae8c2e18128757026897ec095b2475b1d3cddc543b199c2f0a40"
 
   # packages.chef.io was verified as official when first introduced to the cask
-  url "https://packages.chef.io/files/stable/inspec/#{version}/mac_os_x/#{MacOS.version}/inspec-#{version}-1.dmg"
+  url "https://packages.chef.io/files/stable/inspec/#{version}/mac_os_x/10.14/inspec-#{version}-1.dmg"
   appcast "https://github.com/chef/inspec/releases.atom"
   name "InSpec by Chef"
   homepage "https://www.inspec.io/"


### PR DESCRIPTION
Hardcode all the macOS versions to the lowest release. The packages are
all the same and this way we don't fail when we try to fetch a package
for macOS 11.1.

Signed-off-by: Tim Smith <tsmith@chef.io>