### PR TITLE
fix incorrect dmg URL and incorrect pkg name (add .x86_64)

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -2,13 +2,13 @@ cask "chef-workstation" do
   version "21.2.292"
   sha256 "983ee9a08e25fc7e4f0ad3c58b622436aa3831ff1cda4c6e1aefd6720dd41a26"
 
-  url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.14/chef-workstation-#{version}-1.dmg"
+  url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/10.14/chef-workstation-#{version}-1.x86_64.dmg"
   name "Chef Workstation"
   homepage "https://community.chef.io/tools/chef-workstation/"
 
   depends_on macos: ">= :high_sierra"
 
-  pkg "chef-workstation-#{version}-1.pkg"
+  pkg "chef-workstation-#{version}-1.x86_64.pkg"
 
   # When updating this cask, please verify the list of paths to delete and correct it if necessary:
   #   find /usr/local/bin -lname '/opt/chef-workstation/*' | sed -E "s/^(.*)$/'\1',/"


### PR DESCRIPTION
## Description
The filenames of the Chef Workstation dmg and pkg files have changed, but the Homebrew cask has not yet been updated to reflect the changes. Both the dmg and pkg files now have '.x86_64' in their names. This PR adds this, and `brew upgrade` now works correctly, instead of bugging out with a 404.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
