### PR TITLE
Fix for #174

### DIFF
--- a/Casks/chef-infra-client.rb
+++ b/Casks/chef-infra-client.rb
@@ -3,7 +3,7 @@ cask "chef-infra-client" do
   sha256 "4f98965ac0554c0d0a0a5bff8a61cc9c3ac7c09d9f819570326349e26dbb127d"
 
   # packages.chef.io was verified as official when first introduced to the cask
-  url "https://packages.chef.io/files/stable/chef/#{version}/mac_os_x/10.14/chef-#{version}-1.dmg"
+  url "https://packages.chef.io/files/stable/chef/#{version}/mac_os_x/10.14/chef-#{version}-1.x86_64.dmg"
   name "Chef Infra Client"
   homepage "https://community.chef.io/tools/chef-infra/"
 


### PR DESCRIPTION
The URL for downloads changed, but the package description didn't, so here's the fix.

Fixes issue #174

## Description

Adds `.x86_64` to the URL where the tap is searching for the `.dmg` and not finding it.

## Related Issue
#174 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ N/A] I have updated the documentation accordingly.
- [ N/A] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
