### PR TITLE
Make the inspec brew url respect the new url format

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -3,7 +3,7 @@ cask "inspec" do
   sha256 "b14478be249df872fb963203f35dde9894ba205b8eff6044ab16fb783f08c476"
 
   # packages.chef.io was verified as official when first introduced to the cask
-  url "https://packages.chef.io/files/stable/inspec/#{version}/mac_os_x/10.14/inspec-#{version}-1.dmg"
+  url "https://packages.chef.io/files/stable/inspec/#{version}/mac_os_x/10.14/inspec-#{version}-1.x86_64.dmg"
   appcast "https://github.com/chef/inspec/releases.atom"
   name "InSpec by Chef"
   homepage "https://community.chef.io/tools/chef-inspec/"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
Extension of the work done in https://github.com/chef/homebrew-chef/pull/175 which addresses this issue https://github.com/chef/homebrew-chef/issues/174 but for the inspec package as opposed to for chef-infra-client.  chef-workstation already has the new url and chefdk does not appear to have transitioned to using the new url format yet.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Added 'x86_64.' to the url so that you can install it with brew again.

As per your contributing file, I believe this to be an "obvious fix".

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
