### PR TITLE
Un-broke cask after multi-architecture change

### DIFF
--- a/Casks/chef-infra-client.rb
+++ b/Casks/chef-infra-client.rb
@@ -1,10 +1,13 @@
 cask "chef-infra-client" do
   version "16.11.7"
-  sha256 "49af5f17c92378374fcb0fa65e78d7a48dee928a7a19edca24186d695120bedf"
 
   # packages.chef.io was verified as official when first introduced to the cask
-  url "https://packages.chef.io/files/stable/chef/#{version}/mac_os_x/10.14/chef-#{version}-1.x86_64.dmg"
+  if Hardware::CPU.intel?
+    url "https://packages.chef.io/files/stable/chef/#{version}/mac_os_x/10.14/chef-#{version}-1.x86_64.dmg"
+    sha256 "49af5f17c92378374fcb0fa65e78d7a48dee928a7a19edca24186d695120bedf"
+  end
   name "Chef Infra Client"
+  desc "Infrastructure client for Chef"
   homepage "https://community.chef.io/tools/chef-infra/"
 
   depends_on macos: ">= :high_sierra"
@@ -14,8 +17,8 @@ cask "chef-infra-client" do
   # As suggested in https://docs.chef.io/install_dk.html#mac-os-x
   uninstall_postflight do
     system_command "/usr/bin/find",
-      args: ["/usr/local/bin", "-lname", "/opt/chef/*", "-delete"],
-      sudo: true
+                   args: ["/usr/local/bin", "-lname", "/opt/chef/*", "-delete"],
+                   sudo: true
   end
 
   uninstall pkgutil: "com.getchef.pkg.chef",


### PR DESCRIPTION
XXX TODO: Add packages for M1.

The cask was not working because it was malformed, so I fixed it.

## Description

People can now install the client.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ x All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
