### PR TITLE
Incorrect SHA256 for M1 machines on Chef Workstation 22.4.861 homebrew cask

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -6,7 +6,7 @@ cask "chef-workstation" do
   if Hardware::CPU.intel?
     sha256 "ac3e8643910528628f164a4f57ef1230f71a8c74ed6548ac1cb914d261081c03"
   else
-    sha256 "ac3e8643910528628f164a4f57ef1230f71a8c74ed6548ac1cb914d261081c03"
+    sha256 "ee8808088f684fd600f5751abe5f1bafa982637d53cfc7a89c31b2eb1fc997b3"
   end
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/#{macos_version}/chef-workstation-#{version}-1.#{arch}.dmg"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

Fix incorrect sha256. 

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The intel sha256 is used for both intel and arm for Chef Workstation 22.4.861 cask. 

Grabbed the correct M1 sha256 from: https://www.chef.io/downloads/tools/workstation

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

https://github.com/chef/homebrew-chef/issues/262

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
