### PR TITLE
Correct the arm64 sha value, update per homebrew main cask repo

### DIFF
--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,5 +1,5 @@
 cask "chef-workstation" do
-  arch, macos_version = Hardware::CPU.intel? ? ["x86_64", "10.15"] : ["arm64", "11"]
+  arch, macos_version = Hardware::CPU.intel? ? %w(x86_64 10.15) : %w(arm64 11)
 
   version "22.4.861"
 

--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,5 +1,5 @@
 cask "chef-workstation" do
-  arch, macos_version = Hardware::CPU.intel? ? %w(x86_64 10.15) : %w(arm64 11)
+  arch, macos_version = Hardware::CPU.intel? ? %w{x86_64 10.15} : %w{arm64 11}
 
   version "22.4.861"
 

--- a/Casks/chef-workstation.rb
+++ b/Casks/chef-workstation.rb
@@ -1,18 +1,18 @@
 cask "chef-workstation" do
-  arch = Hardware::CPU.intel? ? "x86_64" : "arm64"
-  macos_version = Hardware::CPU.intel? ? "10.15" : "11"
+  arch, macos_version = Hardware::CPU.intel? ? ["x86_64", "10.15"] : ["arm64", "11"]
 
   version "22.4.861"
+
   if Hardware::CPU.intel?
     sha256 "ac3e8643910528628f164a4f57ef1230f71a8c74ed6548ac1cb914d261081c03"
   else
-    sha256 "ac3e8643910528628f164a4f57ef1230f71a8c74ed6548ac1cb914d261081c03"
+    sha256 "ee8808088f684fd600f5751abe5f1bafa982637d53cfc7a89c31b2eb1fc997b3"
   end
 
   url "https://packages.chef.io/files/stable/chef-workstation/#{version}/mac_os_x/#{macos_version}/chef-workstation-#{version}-1.#{arch}.dmg"
   name "Chef Workstation"
-  desc "all-in-one installer for the tools you need to manage your Chef infrastructure"
-  homepage "https://community.chef.io/tools/chef-workstation"
+  desc "All-in-one installer for the tools you need to manage your Chef infrastructure"
+  homepage "https://docs.chef.io/workstation/"
 
   livecheck do
     url "https://omnitruck.chef.io/stable/chef-workstation/metadata?p=mac_os_x&pv=#{macos_version}&m=#{arch}&v=latest"


### PR DESCRIPTION
Signed-off-by: Vikram Karve <vikram.karve@progress.com>

## Description
Due to an error in the cask definition update script, the x86_64 package SHA256 value got copied inadvertently in the arm64 SHA256 field. This PR corrects the SHA and updates contents in line with https://github.com/Homebrew/homebrew-cask/blob/master/Casks/chef-workstation.rb

## Related Issue
Updating chef-workstation fails with an error related to the incorrect SHA value on Mac M1.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
