### PR TITLE
Remove deprecated appcast stanza and implement livecheck

### DIFF
--- a/Casks/inspec.rb
+++ b/Casks/inspec.rb
@@ -4,7 +4,13 @@ cask "inspec" do
 
   # packages.chef.io was verified as official when first introduced to the cask
   url "https://packages.chef.io/files/stable/inspec/#{version}/mac_os_x/12/inspec-#{version}-1.x86_64.dmg"
-  appcast "https://github.com/chef/inspec/releases.atom"
+
+  livecheck do
+    url "https://github.com/chef/inspec/releases.atom"
+    strategy :page_match
+    regex(%r{href=.*?\/inspec\/releases\/tag/v(\d+(?:\.\d+)*)}i)
+  end
+
   name "InSpec by Chef"
   homepage "https://community.chef.io/tools/chef-inspec/"
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
The appcast stanza is deprecated and homebrew is generating warnings when it is used.  This retires appcast and migrates to the preferred livecheck stanza.

## Related Issue
https://github.com/chef/homebrew-chef/issues/285


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
