### PR TITLE
CHEF-27194 - Remove SLA from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,6 @@
 # Homebrew-Chef
 [![Build status](https://badge.buildkite.com/aca5f240e299768ef33c8ccd90c4f713d56e811e9af8d0300c.svg?branch=master)](https://buildkite.com/chef-oss/chef-homebrew-chef-master-verify)
 
-**Umbrella Project**: [Chef Foundation](https://github.com/chef/chef-oss-practices/blob/master/projects/chef-foundation.md)
-
-**Project State**: [Active](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md#active)
-
-**Issues [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)**: 14 days
-
-**Pull Request [Response Time Maximum](https://github.com/chef/chef-oss-practices/blob/master/repo-management/repo-states.md)**: 14 days
-
 For users on macOS, Chef maintains a [Homebrew](https://brew.sh/) Cask that makes it easy to install and keep up-to-date Chef Infra Client and Chef InSpec.
 
 ## Quick Install


### PR DESCRIPTION
This pull request removes the oft-misleading Chef SLA text from the README.md file.
This action is being taken as part of the [2025 Repo Standardization Initiative](https://github.com/chef-boneyard/oss-repo-standardization-2025). 
As Progress Chef makes a best effort to respond to issues and pull requests in a timely manner, and prioritizes bugfixes and security updates on a customer-driven basis (which may span repos, or have no repo footprint at all), we no longer support the concept of a Service Level Agreement (SLA) on a repository-centric basis. For further details, see [Repo SLA Removal FAQ](https://github.com/chef-boneyard/oss-repo-standardization-2025/blob/main/messaging/sla-removal.md). 