### PR TITLE
Update arm for infra 18.9.4 release. Make Intel version static

### DIFF
--- a/Casks/chef-infra-client.rb
+++ b/Casks/chef-infra-client.rb
@@ -1,18 +1,19 @@
 cask "chef-infra-client" do
-  version "18.8.54"
+  version "18.9.4"
 
   # https://docs.brew.sh/Cask-Cookbook#handling-different-system-configurations
   on_arm do
-    sha256 "970f44abd0e9c080d649511655250322b82ab491be19e9101135319f2516f472"
+    sha256 "d742ce87c2cbf1848128ae11de17590ce14c792f8c233067010fdb1c64dd82bb"
     # packages.chef.io was verified as official when first introduced to the cask
-    url "https://packages.chef.io/files/current/chef/#{version}/mac_os_x/12/chef-#{version}-1.arm64.dmg"
+    url "https://packages.chef.io/files/current/chef/#{version}/mac_os_x/13/chef-#{version}-1.arm64.dmg"
     pkg "chef-#{version}-1.arm64.pkg"
   end
 
+  # last Intel release
   on_intel do
     sha256 "79767d80fe9041de710c79c6076e8f7217ba248bd7f1e24aa876d762b88c363c"
-    url "https://packages.chef.io/files/current/chef/#{version}/mac_os_x/12/chef-#{version}-1.x86_64.dmg"
-    pkg "chef-#{version}-1.x86_64.pkg"
+    url "https://packages.chef.io/files/current/chef/18.8.54/mac_os_x/12/chef-18.8.54-1.x86_64.dmg"
+    pkg "chef-18.8.54-1.x86_64.pkg"
   end
 
   name "Chef Infra Client"

--- a/Rakefile
+++ b/Rakefile
@@ -20,8 +20,7 @@ module HomebrewChef
         channel: "current",
         product_name: "chef",
         architectures: [
-          { architecture: "arm64", platform_version: "12" },
-          { architecture: "x86_64", platform_version: "12" },
+          { architecture: "arm64", platform_version: "13" },
         ],
         update_urls: true,
       }.freeze,


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
Intel releases stopped with 18.8.54. Preserve that reference and update arm for latest 18 release.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
